### PR TITLE
Improve ItemEditor

### DIFF
--- a/Assets/SchwerScripts/ItemSystem/Editor/ItemEditor.cs
+++ b/Assets/SchwerScripts/ItemSystem/Editor/ItemEditor.cs
@@ -61,7 +61,7 @@ namespace SchwerEditor.ItemSystem {
                 }
             }
             else {
-                EditorGUILayout.HelpBox("Select an item from the sidebar to begin editing", MessageType.Info);
+                EditorGUILayout.HelpBox("Select an item from the sidebar to begin editing.", MessageType.Info);
             }
             EditorGUILayout.EndVertical();
 
@@ -77,11 +77,12 @@ namespace SchwerEditor.ItemSystem {
 
             var itemObj = new SerializedObject(item);
 
-            EditorGUILayout.PropertyField(itemObj.FindProperty("_id"));
-            EditorGUILayout.PropertyField(itemObj.FindProperty("_name"));
-            EditorGUILayout.PropertyField(itemObj.FindProperty("_description"));
-            EditorGUILayout.PropertyField(itemObj.FindProperty("_sprite"));
-            EditorGUILayout.PropertyField(itemObj.FindProperty("_stackable"));
+            // Reference: https://answers.unity.com/questions/787907/is-there-a-way-to-get-the-names-of-all-serializedp.html
+            var properties = itemObj.GetIterator();
+            properties.NextVisible(true);  // Skip script property
+            while (properties.NextVisible(true)) {
+                EditorGUILayout.PropertyField(properties);
+            }
 
             itemObj.ApplyModifiedProperties();
         }

--- a/Assets/SchwerScripts/ItemSystem/Editor/ItemEditor.cs
+++ b/Assets/SchwerScripts/ItemSystem/Editor/ItemEditor.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Collections.Generic;
 using UnityEditor;
 using UnityEditor.Callbacks;
 using UnityEngine;
@@ -32,6 +33,8 @@ namespace SchwerEditor.ItemSystem {
     }
 
     public class ItemEditor : EditorWindow {
+        private Item selectedItem;
+
         [MenuItem("Item System/Open Item Editor")]
         public static void ShowWindow() => GetWindow<ItemEditor>("Item Editor");
         public static void ShowWindow(Item item) {
@@ -39,7 +42,6 @@ namespace SchwerEditor.ItemSystem {
             window.selectedItem = item;
         }
 
-        private Item selectedItem;
         private void OnGUI() {
             Repaint();
 
@@ -91,10 +93,40 @@ namespace SchwerEditor.ItemSystem {
         }
 
         private Item DrawItemsSidebar(Item[] items) {
+            var button = new GUIStyle(GUI.skin.button);
+            button.alignment = TextAnchor.MiddleLeft;
+
+            var regCol = GUI.backgroundColor;
+            var selCol = new Color(0.239f, 0.501f, 0.874f);
+            var selTxt = Color.white;
+            var dupCol = new Color(0.866f, 0.258f, 0.250f);
+            var dupTxt = dupCol;
+
+            var ids = new HashSet<int>();
             foreach (var item in items) {
-                EditorGUILayout.BeginHorizontal();
-                GUILayout.Label(item.id.ToString(), GUILayout.MaxWidth(28));
-                if (GUILayout.Button(item.name)) {
+                var selected = (selectedItem == item);
+                var dupeID = (!ids.Add(item.id));
+
+                var label = new GUIStyle(GUI.skin.label);
+
+                if (selected || dupeID) {
+                    label.normal.textColor = selTxt;
+                    if (selected) {
+                        GUI.backgroundColor = selCol;
+                        if (dupeID) {
+                            label.normal.textColor = dupTxt;
+                        }
+                    }
+                    else {
+                        GUI.backgroundColor = dupCol;
+                    }
+                }
+
+                EditorGUILayout.BeginHorizontal("box");
+                GUI.backgroundColor = regCol;
+
+                GUILayout.Label(item.id.ToString(), label, GUILayout.MinWidth(28), GUILayout.ExpandWidth(false));
+                if (GUILayout.Button(item.name, button)) {
                     selectedItem = item;
                 }
 

--- a/Assets/SchwerScripts/ItemSystem/Editor/ItemEditor.cs
+++ b/Assets/SchwerScripts/ItemSystem/Editor/ItemEditor.cs
@@ -59,7 +59,7 @@ namespace SchwerEditor.ItemSystem {
                 }
             }
             else {
-                EditorGUILayout.LabelField("Select an item from the list.");
+                EditorGUILayout.HelpBox("Select an item from the sidebar to begin editing", MessageType.Info);
             }
             EditorGUILayout.EndVertical();
 
@@ -71,6 +71,8 @@ namespace SchwerEditor.ItemSystem {
         }
 
         private void DrawItemProperties(Item item) {
+            DrawDisabledItemField(item);
+
             var itemObj = new SerializedObject(item);
 
             EditorGUILayout.PropertyField(itemObj.FindProperty("_id"));
@@ -82,6 +84,12 @@ namespace SchwerEditor.ItemSystem {
             itemObj.ApplyModifiedProperties();
         }
 
+        private void DrawDisabledItemField(Item item) {
+            EditorGUI.BeginDisabledGroup(true);
+            EditorGUILayout.ObjectField(item, typeof(Item), false);
+            EditorGUI.EndDisabledGroup();
+        }
+
         private Item DrawItemsSidebar(Item[] items) {
             foreach (var item in items) {
                 EditorGUILayout.BeginHorizontal();
@@ -89,6 +97,7 @@ namespace SchwerEditor.ItemSystem {
                 if (GUILayout.Button(item.name)) {
                     selectedItem = item;
                 }
+
                 EditorGUILayout.EndHorizontal();
             }
             return selectedItem;

--- a/Assets/SchwerScripts/ItemSystem/Inventory.cs
+++ b/Assets/SchwerScripts/ItemSystem/Inventory.cs
@@ -127,6 +127,8 @@ namespace Schwer.ItemSystem {
         //! Called every frame when Inventory is inspected, as this is how Unity displays objects in the Inspector.
         public void OnBeforeSerialize() => DictionaryToLists();
         public void OnAfterDeserialize() {} // No writing to dictionary
+        // public void OnAfterDeserialize() => ListsToDictionary();
+        // // UnityException: ToString is not allowed to be called during serialization, call it from OnEnable instead. Called from ScriptableObject 'InventorySO'.
 
         private void DictionaryToLists() {
             keys = new List<Item>();
@@ -135,6 +137,12 @@ namespace Schwer.ItemSystem {
             foreach (var kvp in this) {
                 keys.Add(kvp.Key);
                 values.Add(kvp.Value);
+            }
+        }
+
+        private void ListsToDictionary() {
+            for (int i = 0; i < Math.Min(keys.Count, values.Count); i++) {
+                this.Add(keys[i], values[i]);
             }
         }
 


### PR DESCRIPTION
- Replace LabelField with a HelpBox when no item is selected.
- Draw disabled ObjectField when an `Item` is selected for quick access to the `Item` asset.
- Add colour highlighting in sidebar.
    - Selection highlight takes precedence over duplicate ID highlighting (text will change color if selected and id is duplicate).
- Replace FindProperty with iterator when drawing Item properties.
    - Should allow all serializable fields on `Item` and derived classes to be edited via the `ItemEditor` without needing further modification.